### PR TITLE
Fixed Mozilla parsing

### DIFF
--- a/src/bin/tl-create.js
+++ b/src/bin/tl-create.js
@@ -135,7 +135,10 @@ function parseMozillaTrusted() {
 }
 
 function parseMozillaDisallowed() {
-    throw "Mozilla disallowed certificates not yet implemented.";
+    console.log("Trust Lists: Mozilla");
+    var moz = new tl_create.Mozilla();
+    var tl = moz.getDisallowed();
+    return tl;
 }
 
 function parseMicrosoftTrusted() {
@@ -181,6 +184,8 @@ var filter = program.for.split(",");
 
 function trustFilter(item, index) {
     if (item.source === "EUTL")
+        return true;
+    if (item.trust.indexOf("ANY") !== -1)
         return true;
     for (var i in filter) {
         var f = filter[i];

--- a/src/formats/apple.ts
+++ b/src/formats/apple.ts
@@ -32,7 +32,7 @@ namespace tl_create {
 
                 let tl_cert: X509Certificate = {
                     raw: certraw,
-                    trust: [],
+                    trust: [ "ANY" ],
                     operator: decodeURI(certname.slice(0, -4)),
                     source: "Apple",
                     evpolicy: evpolicies
@@ -66,7 +66,7 @@ namespace tl_create {
                     certraw = this.getDistrustedCert(tlVersion, certname);
                 let tl_cert: X509Certificate = {
                     raw: certraw,
-                    trust: [],
+                    trust: [ "ANY" ],
                     operator: decodeURI(certname.slice(0, -4)),
                     source: "Apple",
                     evpolicy: evpolicies

--- a/test/mozilla.js
+++ b/test/mozilla.js
@@ -14,14 +14,24 @@ var fs = require("fs");
 
 describe("Mozilla format", function () {
 
-    it("Parse incoming text", function () {
+    it("Parse incoming text for trusted roots", function () {
         // get static file
         var mozText = fs.readFileSync("./test/static/mozilla.txt", "utf8");
 
         var moz = new tl_create.Mozilla();
         var tl = moz.getTrusted(mozText);
-        
-        assert.equal(tl.Certificates.length, 177);
+
+        assert.equal(tl.Certificates.length, 157);
+    });
+
+    it("Parse incoming text for disallowed roots", function () {
+        // get static file
+        var mozText = fs.readFileSync("./test/static/mozilla.txt", "utf8");
+
+        var moz = new tl_create.Mozilla();
+        var tl = moz.getDisallowed(mozText);
+
+        assert.equal(tl.Certificates.length, 19);
     });
 
 })


### PR DESCRIPTION
Mozilla parsing would output all certificates as trusted, even ones with
CKT_NSS_NOT_TRUSTED set. This was fixed and the disallowed option was added
for Mozilla too.