### PR TITLE
Fixed apple parsing

### DIFF
--- a/built/tl-create.js
+++ b/built/tl-create.js
@@ -951,7 +951,7 @@ var tl_create;
             var filenames = [];
             ch("td").has("img").find("a").each(function (i, anchor) {
                 var href = anchor.attribs["href"];
-                if (href.endsWith("/certificates/") || (href === "AppleDEVID.cer"))
+                if (href.endsWith("/certificates/") || href.endsWith("/../") || (href === "AppleDEVID.cer"))
                     return;
                 filenames.push(href);
             });
@@ -967,7 +967,7 @@ var tl_create;
             var filenames = [];
             ch("td").has("img").find("a").each(function (i, anchor) {
                 var href = anchor.attribs["href"];
-                if (href.endsWith("/certificates/"))
+                if (href.endsWith("/certificates/") || href.endsWith("/../"))
                     return;
                 filenames.push(href);
             });
@@ -1079,4 +1079,3 @@ var tl_create;
 })(tl_create || (tl_create = {}));
 if (typeof module !== "undefined")
     module.exports = tl_create;
-//# sourceMappingURL=tl-create.js.map

--- a/src/formats/apple.ts
+++ b/src/formats/apple.ts
@@ -121,7 +121,7 @@ namespace tl_create {
 
             ch("td").has("img").find("a").each(function(i, anchor) {
                 let href = (<any>anchor.attribs)["href"];
-                if(href.endsWith("/certificates/") || (href === "AppleDEVID.cer"))
+                if(href.endsWith("/certificates/") || href.endsWith("/../") || (href === "AppleDEVID.cer"))
                     return;
 
                 filenames.push(href);
@@ -141,7 +141,7 @@ namespace tl_create {
 
             ch("td").has("img").find("a").each(function(i, anchor) {
                 let href = (<any>anchor.attribs)["href"];
-                if(href.endsWith("/certificates/"))
+                if(href.endsWith("/certificates/") || href.endsWith("/../"))
                     return;
 
                 filenames.push(href);


### PR DESCRIPTION
Apple changed the format of the web page that contains all certificates
(https://opensource.apple.com/source/security_certificates/) and in particular
the anchor to the parent page. Tl-create can now correctly parse both the older
and the newer format.