### PR TITLE
Reject untrusted TLS certificates

### DIFF
--- a/src/bin/tl-create.js
+++ b/src/bin/tl-create.js
@@ -29,8 +29,6 @@ var parsedRootCount = 0;
 var errorParsedRootCount = 0;
 var totalRootsSkip = 0;
 
-process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0';
-
 /*
  * Utility functions 
  * 


### PR DESCRIPTION
The problematic server that serves a member state TSL fixed its TLS configuration and now TLS certificate validation can be re-enabled.