### PR TITLE
Ignore .python-version for users compiling via pyenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.python-version
 .vscode
 .idea
 node_modules


### PR DESCRIPTION
For those users that need `pyenv` to switch to Python 2 locally in this directory during the `npm install` process (which uses `node gyp-rebuild`, which requires Python 2).