### PR TITLE
Update xmldsigjs to the latest version with important EUTL-related fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ before_install:
   - node --version
   - npm --version
   - gcc --version
-  - npm install mocha -g
 
 script:
   - npm test

--- a/package.json
+++ b/package.json
@@ -29,12 +29,13 @@
     "xmldsigjs": "^2.0.25"
   },
   "devDependencies": {
-    "typescript": "^2.7.2",
     "@types/asn1js": "0.0.1",
     "@types/cheerio": "^0.22.0",
     "@types/node": "^7.0.10",
     "@types/pkijs": "0.0.1",
-    "@types/pvutils": "0.0.1"
+    "@types/pvutils": "0.0.1",
+    "mocha": "^5.2.0",
+    "typescript": "^2.7.2"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -16,17 +16,17 @@
     "asn1js": "latest",
     "babel-polyfill": "^6.26.0",
     "cheerio": "^0.22.0",
+    "child_process": "^1.0.2",
     "commander": "^2.9.0",
     "node-webcrypto-ossl": "^1.0.7",
     "pkijs": "latest",
     "pvutils": "latest",
     "sync-request": "^3.0.1",
+    "temp": "^0.8.3",
     "xadesjs": "^2.0.11",
     "xml-core": "^1.0.10",
     "xmldom-alpha": "^0.1.23",
-    "xmldsigjs": "^2.0.19",
-    "temp": "^0.8.3",
-    "child_process": "^1.0.2"
+    "xmldsigjs": "^2.0.25"
   },
   "devDependencies": {
     "typescript": "^2.7.2",


### PR DESCRIPTION
This PR fixes the problem with getting EUTL, since it now contains XML which is signed with http://www.w3.org/2007/05/xmldsig-more#sha256-rsa-MGF1

The latest `xmldsigjs` adds support to verify Signature with that algorithm.
Without this change, got the error: 
`Error: signature algorithm 'http://www.w3.org/2007/05/xmldsig-more#sha256-rsa-MGF1' is not supported`
