### PR TITLE
Update node versions on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "6"
-  - "5"
+  - "7"
+  - "10"
   
 env:
   - CXX=g++

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ before_install:
   - node --version
   - npm --version
   - gcc --version
-  - npm install mocha -g
 
 script:
   - npm test

--- a/package.json
+++ b/package.json
@@ -29,12 +29,13 @@
     "child_process": "^1.0.2"
   },
   "devDependencies": {
-    "typescript": "^2.7.2",
     "@types/asn1js": "0.0.1",
     "@types/cheerio": "^0.22.0",
     "@types/node": "^7.0.10",
     "@types/pkijs": "0.0.1",
-    "@types/pvutils": "0.0.1"
+    "@types/pvutils": "0.0.1",
+    "mocha": "^6.1.4",
+    "typescript": "^2.7.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Support for old versions are dropped by dependencies, for example, `xmldsigjs`, and transpilers (`babel`).

So this PR is a proposal to drop official support for node v5,6. And begin tests on CI from node v7.
Also, this project [already uses](https://github.com/PeculiarVentures/tl-create/blob/master/package.json#L35) ts typings for node v7.
