### PR TITLE
Update Mozilla URL to actual and secured one

### DIFF
--- a/src/formats/mozilla.ts
+++ b/src/formats/mozilla.ts
@@ -57,7 +57,7 @@ declare type MozillaAttribute = {
   value: any;
 };
 
-const mozillaURL = "http://mxr.mozilla.org/mozilla/source/security/nss/lib/ckfw/builtins/certdata.txt?raw=1";
+const mozillaURL = "https://hg.mozilla.org/mozilla-central/raw-file/tip/security/nss/lib/ckfw/builtins/certdata.txt";
 
 export class Mozilla {
 


### PR DESCRIPTION
Related to: https://github.com/PeculiarVentures/tl-create/issues/76.

Since the old URL:
```
http://mxr.mozilla.org/mozilla/source/security/nss/lib/ckfw/builtins/certdata.txt?raw=1
```
May not respond and respond with 301 (Permanently moved), there is a reason to update to the actual url.
```
https://hg.mozilla.org/mozilla-central/raw-file/tip/security/nss/lib/ckfw/builtins/certdata.txt
```